### PR TITLE
Add Jetpack Compose FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 - [Raywenderlich - Jetpack Compose Primer](https://www.raywenderlich.com/3604589-jetpack-compose-primer/lessons/1)
 
 ## Extras
+- [Jetpack Compose FAQ](https://github.com/Mishkun/jetpack-compose-faq)
 - [Video - Kotlin and Jetpack Compose](https://www.youtube.com/watch?v=KjQU_QrlbEI)
 - `#compose` channel on [Kotlin Slack](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up)
 


### PR DESCRIPTION
The [Jetpack Compose FAQ](https://github.com/Mishkun/jetpack-compose-faq) probably deserves a link. I was not certain what category it belonged to, so I put it in "Extras".